### PR TITLE
FEAT: Atualizar o AuthController com validação e implementar testes

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,12 +2,47 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Merchant;
+use App\Models\User;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
 
 class AuthController extends Controller
 {
-    public function postAuthenticate(string $response)
+    public function postAuthenticate(Request $request, string $provider)
     {
-        return response('O reponse escolhido é ' . $response . 200);
+
+        $this->validate($request, [
+            'email' => 'required|email',
+            'password' => 'required'
+        ]);
+
+
+        $providers = ['user', 'merchant'];
+
+        if (!in_array($provider, $providers)) {
+            return response()->json(['errors' => ['main' => 'Wrong provider']], 422);
+        }
+
+        $provider = $this->getProvider($provider);
+
+        $model = $provider->where('email', '=', $request->input('email'))->first();
+
+        if(!$model) {
+            return response()->json(['errors' => ['main' => 'Wrong credentials']], 401);
+        }
+
+        return 'O response escolhido é ' . $provider;
+    }
+
+    public function getProvider(string $provider): Authenticatable
+    {
+        if ($provider == 'user') {
+            return new User();
+        }else if ($provider == 'merchant') {
+            return new Merchant();
+        } else {
+            throw new \InvalidArgumentException('Invalid provider');
+        }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,4 +19,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::get('/auth/{provider}', [AuthController::class, 'postAuthenticate']);
+Route::post('/auth/{provider}', [AuthController::class, 'postAuthenticate'])->name('authenticate');

--- a/tests/Feature/app/Http/Controllers/AuthcontrollerTest.php
+++ b/tests/Feature/app/Http/Controllers/AuthcontrollerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\app\Http\Controllers;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\TestCase;
+
+class AuthcontrollerTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    public function testUserCannotAuthenticateWithTheWrongSupplier()
+    {
+        $payload = [
+            'email' => 'test@test.com',
+            'password' => 'password',
+        ];
+        $response = $this->post(route('authenticate', ['provider' => 'unknownProvider']), $payload);
+
+        $response->assertStatus(422);
+        $response->assertJson(['errors' => ['main' => 'Wrong provider']]);
+    }
+
+    public function testUserShouldBeDeniedIfNotRegistered()
+    {
+        $payload = [
+            'email' => 'test@test.com',
+            'password' => 'password',
+        ];
+        $response = $this->post(route('authenticate', ['provider' => 'merchant']), $payload);
+        $response->assertStatus(401);
+        $response->assertJson(['errors' => ['main' => 'Wrong credentials']]);
+    }
+
+}
+


### PR DESCRIPTION
Este commit introduz a validação de e-mail e senha no método postAuthenticate do AuthController. Também diferencia entre os fornecedores “utilizador” e “comerciante” e trata a entrada inválida. Além disso, foram incluídos casos de teste para erros de provedor errado e credenciais erradas.